### PR TITLE
Remove usage of simplejson

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -52,6 +52,8 @@ To tweak a format, simply override it's ``to_<format>`` & ``from_<format>``
 methods. So adding the server time to all output might look like so::
 
     import time
+    import json
+    from django.core.serializers.json import DjangoJSONEncoder
     from tastypie.serializers import Serializer
     
     
@@ -64,11 +66,11 @@ methods. So adding the server time to all output might look like so::
             # Add in the current time.
             data['requested_time'] = time.time()
 
-            return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True)
-        
+            return json.dumps(data, cls=DjangoJSONEncoder, sort_keys=True)
+
         def from_json(self, content):
-            data = simplejson.loads(content)
-            
+            data = json.loads(content)
+
             if 'requested_time' in data:
                 # Log the request here...
                 pass


### PR DESCRIPTION
Suppresses warnings (noise in Sentry / logs).

Cherry-picked this from upstream. We still have a few uses of simplejson but only inside the test suite (of tastypie) which we don't currently run. Once this merges, will open a PR in our THM repo to run our test suite against a new internal release of tastypie to make sure our suite passes with these changes.